### PR TITLE
Fixed issue on MacOS with locating the VMX

### DIFF
--- a/provider/vix/vm.go
+++ b/provider/vix/vm.go
@@ -154,7 +154,13 @@ func (v *VM) Create() (string, error) {
 	files, _ := filepath.Glob(pattern)
 
 	if len(files) == 0 {
-		return "", fmt.Errorf("[ERROR] vmx file was not found: %s", pattern)
+		// Try another patthern match. MacOS in particular seems to not understand the pattern above when
+		// there are subdirectories involved
+		pattern := filepath.Join(goldPath, "**/*.vmx")
+		files, _ = filepath.Glob(pattern)
+
+		if len(files) == 0 {
+			return "", fmt.Errorf("[ERROR] vmx file was not found: %s", pattern)
 	}
 
 	vmxFile := files[0]

--- a/provider/vix/vm.go
+++ b/provider/vix/vm.go
@@ -161,6 +161,7 @@ func (v *VM) Create() (string, error) {
 
 		if len(files) == 0 {
 			return "", fmt.Errorf("[ERROR] vmx file was not found: %s", pattern)
+		}
 	}
 
 	vmxFile := files[0]


### PR DESCRIPTION
When I ran this on my Mac using the basic resource I found it could not locate the VMX in the subdirectory terraform uses to store the image.

Added a secondary pattern check to fix this. 